### PR TITLE
Fix path to sam2tsv in singularity instructions

### DIFF
--- a/dockerfile/README.md
+++ b/dockerfile/README.md
@@ -4,5 +4,5 @@ docker run -it -d --rm --name epivar2 -v "$PWD/xiao_data/":/project/ epi12 pytho
 ## use singularity and qsub on cluster
 singularity pull docker://huanleliu/epi12
 
-singularity exec -e /full/path/to/epi12_latest.sif python3 /usr/local/bin/EpiNano/Epinano_Variants.py -R /path/to/ref.fa -b /path/to/reads.bam -s /usr/bin/EpiNano/misc/sam2tsv.jar -n 2
+singularity exec -e /full/path/to/epi12_latest.sif python3 /usr/local/bin/EpiNano/Epinano_Variants.py -R /path/to/ref.fa -b /path/to/reads.bam -s /usr/local/bin/EpiNano/misc/sam2tsv.jar -n 2
 


### PR DESCRIPTION
I'm running EpiNano using singularity and discovered that the path to sam2tsv.jar was incorrect in the README, causing an error.  I have corrected it.