### PR TITLE
Don't jumble column order in Epinano_Predict

### DIFF
--- a/Epinano_Predict.py
+++ b/Epinano_Predict.py
@@ -67,8 +67,8 @@ for c in cols_in.split(','):
         cols.append(int(c))
 #columns_to_consider = cols #p (int, args['columns'].split(',')) ### 1-based column index e.g.  8,11 (q, mis)
 #cols = [i -1 for i in columns_to_consider]
-cols.sort()
 cols = list (set(cols))
+cols.sort()
 cols = [x-1 for x in cols]
 mod_col = int (args['modification_status_column']) - 1 if args['modification_status_column'] else None
 


### PR DESCRIPTION
I noticed that although I gave `--columns 7,9,11` to `Epinano_Predict.py`, the output file name contained the string `mis.del.q_median.MODEL`, which has the column names in a different order.  I looked at the source code and noticed that the column numbers were converted a set after sorting, which randomizes the order.  I don't know if this would cause a problem with prediction (I hope not but it makes me very nervous!) but I thought I would at least submit a pull request for your review.